### PR TITLE
Resolve Relative links

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,7 @@ use tokio::{
     io::{AsyncWriteExt, BufWriter},
 };
 use tracing::info;
-use url::Url;
 
-/// Simple program to greet a person
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 enum Args {

--- a/src/render.rs
+++ b/src/render.rs
@@ -91,13 +91,15 @@ pub async fn render_doc(path: impl AsRef<Path>, use_websocket: bool) -> anyhow::
                 if let Ok(file_path) = dest_url.parse::<PathBuf>() {
                     // Rewrite the URL to open correctly
                     if let Some(file_path) = file_path.to_str() {
-                        // If it's a relative path, resolve it
-                        let file_path = if PathBuf::from(file_path).is_relative() {
-                            rel_to_abspath(file_path, path.clone())
+                        // If the path contains references to parent directories, resolve it
+                        let file_path = if Path::new(&file_path)
+                            .components()
+                            .any(|c| matches!(c, std::path::Component::ParentDir))
+                        {
+                            rel_to_abspath(&file_path, path.clone())
                         } else {
-                            file_path.to_string()
+                            file_path.into()
                         };
-                        // Write the URL
                         *dest_url = format!("/?path={}", file_path).into()
                     }
                 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -89,18 +89,22 @@ pub async fn render_doc(path: impl AsRef<Path>, use_websocket: bool) -> anyhow::
             if !dest_url.parse::<Url>().is_ok() {
                 // Otherwise, try to parse it as a file path
                 if let Ok(file_path) = dest_url.parse::<PathBuf>() {
-                    // Rewrite the URL to open correctly
+                    // If it's a filepath check if it's relative
                     if let Some(file_path) = file_path.to_str() {
-                        // If the path contains references to parent directories, resolve it
-                        let file_path = if Path::new(&file_path)
-                            .components()
-                            .any(|c| matches!(c, std::path::Component::ParentDir))
-                        {
-                            rel_to_abspath(&file_path, path.clone())
+                        let file_path = if Path::new(file_path).is_relative() {
+                            // If it's relative, join it to the current file
+                            join_and_canonicalize(&file_path, path.clone())
                         } else {
+                            // Otherwise, use the file path as is
                             file_path.into()
                         };
-                        *dest_url = format!("/?path={}", file_path).into()
+
+                        // If possible, return a relative path from the cwd
+                        let file_path = match get_relative_path_under_cwd(file_path.clone()) {
+                            Some(path) => path,
+                            None => file_path,
+                        };
+                        *dest_url = format!("/?path={}", file_path.to_str().unwrap()).into()
                     }
                 }
             }
@@ -119,10 +123,39 @@ pub async fn render_doc(path: impl AsRef<Path>, use_websocket: bool) -> anyhow::
     Ok(template.render().unwrap())
 }
 
-/// Converts a relative file path to an absolute path using a reference file path.
+/// Returns a relative path to a file if it is under the working directory
 ///
-/// This function takes a relative file path and a current absolute file path,
-/// it returns the absolute path of the target file. It does not panic.
+/// # Arguments
+/// * `file_path` - A `PathBuf` representing the file or directory path to check and convert if necessary.
+///
+/// # Returns
+/// * A `PathBuf` object containing either a relative or absolute path to the `file_path`.
+///
+/// # Examples
+/// ```
+/// use std::path::PathBuf;
+/// let file_path = std::env::current_dir().unwrap().join("file.txt");
+/// let path = get_relative_or_absolute_path(file_path).unwrap();
+/// println!("{:?}", path); // Outputs the relative or absolute path to "file.txt"
+/// ```
+fn get_relative_path_under_cwd(file_path: PathBuf) -> Option<PathBuf> {
+    if let Ok(current_dir) = std::env::current_dir() {
+        if is_child_path(current_dir, file_path.clone()) {
+            truncate_cwd(&file_path)
+        } else {
+            Some(file_path)
+        }
+    } else {
+        Some(file_path)
+    }
+}
+
+/// Joins a relative link to a the directory of the current file and returns the canonical path
+/// Unlike the std::path::PathBuf::canonicalize method, this function does not panic if the file does not exist.
+///
+/// This function is used to resolve the link to a target from a markdown file
+/// It does not panic.
+/// TODO it should return an enum and be unwrapped above
 ///
 /// Note: The `current_file` input must correspond to a file path, not a directory path.
 ///
@@ -140,7 +173,7 @@ pub async fn render_doc(path: impl AsRef<Path>, use_websocket: bool) -> anyhow::
 /// assert_eq!(rel_to_abspath("../linux.md", current_file), String::from("/home/user/Notes/slipbox/linux.md"));
 /// ```
 ///
-fn rel_to_abspath(path: &str, current_file: PathBuf) -> String {
+fn join_and_canonicalize(path: &str, current_file: PathBuf) -> PathBuf {
     let current_dir = current_file
         .parent()
         .unwrap_or_else(|| &current_file)
@@ -159,7 +192,81 @@ fn rel_to_abspath(path: &str, current_file: PathBuf) -> String {
         }
     }
 
-    clean_path.to_str().unwrap_or_else(|| path).to_string()
+    clean_path
+}
+
+/// Takes an absolute path of a file under the current working directory
+/// and returns a relative path with the current working directory removed.
+/// If the input path does not start with the current working directory, or if there's an error retrieving the current working directory,
+/// this function None
+///
+/// # Arguments
+/// * `file_path` - A reference to a PathBuf object representing the absolute path from which to remove the current working directory.
+///
+/// # Returns
+/// * A PathBuf object representing the relative path with the current working directory removed, or a copy of the input path if this is not possible.
+///
+/// # Examples
+/// ```
+/// use std::path::PathBuf;
+/// let path = PathBuf::from("/home/user/documents/file.txt");
+/// let truncated_path = try_truncate_cwd(&path);
+/// println!("{}", truncated_path.display().unwrap());
+/// // Outputs "documents/file.txt" if current working directory is "/home/user"
+/// ```
+fn truncate_cwd(file_path: &PathBuf) -> Option<PathBuf> {
+    let current_dir = std::env::current_dir().ok()?;
+    let file_path = PathBuf::from(file_path);
+    Some(
+        file_path
+            .strip_prefix(&current_dir)
+            .ok()?
+            .into_iter()
+            .map(|p| p.to_owned())
+            .collect(),
+    )
+}
+
+/// Takes two absolute paths and returns true if the second is a child of the first.
+///
+/// # Arguments
+/// * `parent_dir` - A PathBuf object representing the parent directory.
+/// * `child` - A PathBuf object representing the candidate child
+///
+/// # Returns
+/// * A boolean value indicating whether the second path is a child of the first.
+///
+/// # Examples
+/// ```
+/// use std::path::PathBuf;
+/// let parent_dir = PathBuf::from("/home/user/Notes/slipbox/");
+/// let child = PathBuf::from("/home/user/Notes/slipbox/child.md");
+/// assert_eq!(is_child_path(parent_dir, child), true);
+/// ```
+fn is_child_path(parent_dir: PathBuf, child: PathBuf) -> bool {
+    if child.is_relative() {
+        return false;
+    }
+
+    // Get the components of both
+    let parent_components: Vec<_> = parent_dir.components().collect();
+    let child_components: Vec<_> = child.components().collect();
+
+    // If the length of child's components is less than or equal to parent's, they cannot be a child path
+    if child_components.len() <= parent_components.len() {
+        return false;
+    }
+
+    // Truncate the child_components
+    let child_components: Vec<_> = child_components[0..parent_components.len()].to_vec();
+
+    for (p, c) in parent_components.iter().zip(child_components.iter()) {
+        if p != c {
+            return false;
+        }
+    }
+
+    true
 }
 
 #[cfg(test)]
@@ -170,19 +277,60 @@ mod tests {
     fn test_rel_to_abspath() {
         let current_file = PathBuf::from("/home/user/Notes/slipbox/networking/dns.md");
         assert_eq!(
-            rel_to_abspath("../linux.md", current_file.clone(),),
-            String::from("/home/user/Notes/slipbox/linux.md")
+            join_and_canonicalize("../linux.md", current_file.clone(),),
+            PathBuf::from("/home/user/Notes/slipbox/linux.md")
         );
 
         let current_dir = current_file.parent().unwrap().to_path_buf();
-        println!("{:?} is a directory: {}", current_dir, current_dir.is_dir());
 
         // If passed a directory, we expect a mistaken link as the function
         // gets the directory with pop and requires the directory
         // to exist in order to test
         assert_eq!(
-            rel_to_abspath("../linux.md", current_dir),
-            String::from("/home/user/Notes/linux.md")
+            join_and_canonicalize("../linux.md", current_dir),
+            PathBuf::from("/home/user/Notes/linux.md")
         );
+
+        // Also preserve relative paths
+        assert_eq!(
+            join_and_canonicalize("../linux.md", PathBuf::from("./networking/dns.md"),),
+            PathBuf::from("linux.md")
+        );
+    }
+
+    #[test]
+    fn test_truncate_cwd() {
+        let file_path = std::env::current_dir().unwrap().join("file.md");
+        assert_eq!(truncate_cwd(&file_path), Some(PathBuf::from("file.md")));
+
+        let file_path = std::env::current_dir().unwrap().join("foo/bar/baz/file.md");
+        assert_eq!(
+            truncate_cwd(&file_path),
+            Some(PathBuf::from("foo/bar/baz/file.md"))
+        );
+    }
+
+    #[test]
+    fn test_is_child_path() {
+        let current_file: PathBuf = PathBuf::from("/home/user/Notes/slipbox/");
+        let file: PathBuf = PathBuf::from("/home/user/Notes/slipbox/child.md");
+
+        // The directory of the current file is the parent directory of the file
+        // So this should return true
+        assert_eq!(is_child_path(current_file, file), true);
+
+        let current_file: PathBuf = PathBuf::from("/home/user/Notes/slipbox/");
+        let file: PathBuf = PathBuf::from("/home/user/Notes/not_child.md");
+
+        // The directory of the current file is the parent directory of the file
+        // So this should return true
+        assert_ne!(is_child_path(current_file, file), true);
+    }
+
+    #[test]
+    fn test_get_relative_path_under_cwd() {
+        let current_dir = std::env::current_dir().unwrap();
+        let child_file = current_dir.join("child_file");
+        assert_eq!(get_relative_path_under_cwd(child_file).unwrap(), PathBuf::from("child_file"));
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -117,10 +117,27 @@ pub async fn render_doc(path: impl AsRef<Path>, use_websocket: bool) -> anyhow::
     Ok(template.render().unwrap())
 }
 
-/// Takes a relative path and a current file, joins them and
-/// returns the absolute path of that target file.
-/// The input must be a current file, not a directory.
-/// This function does not panic, as rendering should push through
+/// Converts a relative file path to an absolute path using a reference file path.
+///
+/// This function takes a relative file path and a current absolute file path,
+/// it returns the absolute path of the target file. It does not panic.
+///
+/// Note: The `current_file` input must correspond to a file path, not a directory path.
+///
+/// # Arguments
+///
+/// * `path` - A str of the relative file path to be converted.
+/// * `current_file` - A PathBuf which holds the path to the current file.
+///
+/// # Return
+///
+/// This function returns a String that represents the absolute path of the target file.
+///
+/// ```
+/// let current_file = PathBuf::from("/home/user/Notes/slipbox/networking/dns.md");
+/// assert_eq!(rel_to_abspath("../linux.md", current_file), String::from("/home/user/Notes/slipbox/linux.md"));
+/// ```
+///
 fn rel_to_abspath(path: &str, current_file: PathBuf) -> String {
     let current_dir = current_file
         .parent()


### PR DESCRIPTION
This improves the link resolution to also resolve relative links.

This is done by:

1. Check if a link is relative (using `.is_relative()`) 
    2. Join the two file path and the relative link, e.g. `PathBuf::from("/home/user/Notes/Code/index.md").join("../Linux/index.md")`
    3. Looping over the components of the path to drop `..`
        - The `.canonicalize()` method is not appropriate here as it tries to resolve symlinks and panics when the file doesn't exist.
        
        
**Consideration**

We could simply call the `.canonicalize()` method and leave the link alone if that fails: 


```rust
if file_path.is_relative() {
    clean_path = path.join(file_path).canonicalize().unwrap_or_else(|_| file_path).to_str();
}
```

- Justification
    - If there's no file, there's no need to have a working link. 
- Pros
    - Simpler more readable code
    - Code won't break if the `std::path::Comonent` enum changes
- Cons
    - User's may expect functioning links even when there aren't files to render 
        - I can't imagine such a use case but I'm sure a user will find it.
